### PR TITLE
Add new cybersecurity educational resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This is an [awesome list](https://github.com/sindresorhus/awesome) of resources 
 * [Cybersecurity Guide](https://cybersecurityguide.org/) – collection of guides
 * [Cyber Security Degrees](https://cybersecuritydegrees.org/) – lists of scholarships, degree programs, and certifications in the USA
 * [eLearnSecurity](https://www.elearnsecurity.com/) – paid online security courses
-* [Exploit Database](https://www.exploit-db.com/) – archive of exploits
 * [Hacker101](https://www.hacker101.com/) – free, open-source video lessons on web security
 * [Hacksplaining](https://www.hacksplaining.com/lessons) – vulnerabilities explained simply
 * [Open Security Training](http://www.opensecuritytraining.info/) – free, open-source materials for computer security classes
@@ -38,6 +37,28 @@ This is an [awesome list](https://github.com/sindresorhus/awesome) of resources 
 * [SANS](https://www.sans.org/) – professional paid information security training
 * [SANS Cyber Aces](https://tutorials.cyberaces.org/) – video tutorials with handouts and quizzes
 * [Teaching Security](https://teachingsecurity.org/) – ready-made materials for classrooms
+
+## PrivEsc and living off the land
+
+* [GTFOBins](https://gtfobins.github.io/) – a curated list of Unix binaries that can be used to bypass local security restrictions
+* [LOLBAS](https://lolbas-project.github.io/) – a public directory of built-in Windows binaries used for bypassing security controls
+* [LOLDrivers](https://loldrivers.io/) – a curated list of legitimately signed Windows drivers used to bypass security tools
+* [LOLESXi](https://lolesxi.github.io/) – a dedicated collection of native VMware ESXi binaries abused for post-exploitation
+* [WADComs](https://wadcoms.github.io/) – an interactive command repository for exploiting Active Directory environments
+
+
+## Cyber playbooks and payload repositories
+
+* [HackTricks](https://book.hacktricks.xyz/) – a comprehensive online book mapping out modern penetration testing methodologies
+* [Ired.team](https://www.ired.team/) – a detailed digital notebook covering operational red teaming and tradecraft tactics
+* [PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings) – a massive repository of copy-paste payloads for web application exploitation
+* [RevShells](https://www.revshells.com/) – an interactive web tool for generating reverse shell commands across multiple languages
+
+## Exploit and threat intelligence databases
+
+* [ATT&CK Matrix](https://attack.mitre.org/) – a globally-accessible knowledge base of adversary tactics and techniques based on real-world observations
+* [CyberChef](https://gchq.github.io/CyberChef/) – a web app known as the "Cyber Army Knife" used for decoding, hashing, and analyzing data
+* [Exploit-DB](https://www.exploit-db.com/) – a public archive of historical and modern software exploits for security researchers
 
 ## Other interesting lists
 


### PR DESCRIPTION
Added  essential cybersecurity reference tools and databases across three categories :

**PrivEsc & Living Off the Land**: GTFOBins, LOLBAS, LOLDrivers, LOLESXi, WADComs.
**Playbooks & Payloads: HackTricks**, Ired.team, PayloadsAllTheThings, RevShells.
**Exploit & Threat Intel**: ATT&CK Matrix, CyberChef.

All resources are formatted in Markdown and alphabetized. 

Please review when you get a chance @valdemarsv !
